### PR TITLE
Handle nested contexts

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -105,7 +105,26 @@
       </svg>
     </section>
 
+    <section data-label='nesting'>
+      <div style='background: red; padding-left: 10px'>
+        <div style='background: red; padding-left: 10px'>a</div>
+        <div style='background: green; padding-left: 10px'>b</div>
+        <div style='background: blue; padding-left: 10px'>c</div>
+      </div>
+      <div style='background: green; padding-left: 10px'>e</div>
+      f
+    </section>
+
+    <section data-label='overflow:hidden'>
+      <div style='width: 100px; height: 100px; overflow: hidden'>
+        <div>averylongword</div>
+        <img src='https://github.com/arnaudjuracek.png?size=200' />
+      </div>
+      <img src='https://github.com/arnaudjuracek.png?size=200' />
+    </section>
+
     <section data-label='clip-path'>
+      <div>before</div>
       <div
         style='
           clip-path: polygon(50px 0px, 100px 50px, 50px 100px, 0px 50px);
@@ -114,8 +133,10 @@
           height: 100px;
         '
       >
-        Hello world
+        Hello <span>world</span>
+        <div>foo<span>bar</span></div>
       </div>
+      <div>after</div>
     </section>
 
     <section data-label='[BUG] negative positioning in clip-path'>
@@ -132,10 +153,10 @@
     </section>
 
     <section data-label='z-index' style='height: 18rem;'>
-      <div style='position: absolute; top: 2rem; left: 14rem; width: 10rem; height: 10rem; background: black;'></div>
-      <div style='position: absolute; top: 2rem; left: 2rem; width: 10rem; height: 10rem; background: red; z-index: 1;'></div>
       <div style='position: absolute; top: 6rem; left: 6rem; width: 10rem; height: 10rem; background: blue; z-index: 1;'></div>
+      <div style='position: absolute; top: 2rem; left: 14rem; width: 10rem; height: 10rem; background: black;'></div>
       <div style='position: absolute; top: 4rem; left: 10rem; width: 10rem; height: 10rem; background: green; z-index: 3;'></div>
+      <div style='position: absolute; top: 2rem; left: 2rem; width: 10rem; height: 10rem; background: red; z-index: 1;'></div>
     </section>
 
     <section data-label='background gradient'>

--- a/example/index.html
+++ b/example/index.html
@@ -152,6 +152,13 @@
       </div>
     </section>
 
+    <section data-label='opacity'>
+      <span style='opacity: 0.5'>
+        hello
+        <span style='opacity: 0.5'>world</span>
+      </span>!
+    </section>
+
     <section data-label='z-index' style='height: 18rem;'>
       <div style='position: absolute; top: 6rem; left: 6rem; width: 10rem; height: 10rem; background: blue; z-index: 1;'></div>
       <div style='position: absolute; top: 2rem; left: 14rem; width: 10rem; height: 10rem; background: black;'></div>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "gradient-parser": "^1.0.2",
-    "opentype.js": "^1.3.4"
+    "opentype.js": "^1.3.4",
+    "uid": "^2.0.2"
   },
   "devDependencies": {
     "eslint": "^8.45.0",

--- a/src/index.js
+++ b/src/index.js
@@ -84,10 +84,12 @@ export default function ({
         // Extract geometric and styling data from element
         const style = window.getComputedStyle(element)
         const { x, y, width, height } = element.getBoundingClientRect()
+        const opacity = style.getPropertyValue('opacity')
         const clipPathValue = style.getPropertyValue('clip-path')
         const overflowValue = style.getPropertyValue('overflow')
 
         if (overflowValue || clipPathValue) Context.push()
+        if (+opacity !== 1) Context.current.setAttribute('opacity', opacity)
 
         // Handle overflow: hidden
         if (overflowValue === 'hidden') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 /* global Node */
 import Opentype from 'opentype.js'
+import { uid } from 'uid'
 import walk from './utils/dom-walk'
 import getZIndex from './utils/dom-get-zindex'
 import getClientRects from './utils/range-get-client-rects'
+import lastOf from './utils/array-last'
 
 import $ from './utils/dom-render-svg'
 import * as RENDERERS from './renderers'
@@ -54,27 +56,57 @@ export default function ({
         preserveAspectRatio: 'none'
       })
 
-      // Set the parent to the current SVG.
-      // This parent will change during the walk
-      let parent = svg
+      const defs = $('defs', null, svg)
+
+      // Set context to root SVG.
+      // Context will change during walk push/pop
+      const Context = (() => {
+        const stack = [svg]
+        const pop = () => stack.length > 0 && stack.pop()
+        const push = () => stack.push($('g', null, lastOf(stack)))
+        return {
+          pop,
+          push,
+          get current () { return lastOf(stack) },
+          apply: depth => {
+            const deltaDepth = depth - (stack.length - 1)
+            for (let i = 0; i < -deltaDepth; i++) pop()
+            for (let i = 0; i < deltaDepth; i++) push()
+          }
+        }
+      })()
 
       // Render every children
-      await walk(container, async element => {
+      await walk(container, async (element, depth, index) => {
         if (ignore && element !== container && element.matches(ignore)) return
+        Context.apply(depth)
 
+        // Extract geometric and styling data from element
         const style = window.getComputedStyle(element)
         const { x, y, width, height } = element.getBoundingClientRect()
+        const clipPathValue = style.getPropertyValue('clip-path')
+        const overflowValue = style.getPropertyValue('overflow')
 
-        if (element instanceof window.HTMLElement) {
-          // TODO opacity
+        if (overflowValue || clipPathValue) Context.push()
 
-          // Handle CSS clip-path property
-          const clipPathValue = style.getPropertyValue('clip-path')
-          if (clipPathValue !== 'none') {
-            parent = $('g', null, svg)
-            // WARNING: CSS clip-path implementation is not done yet on arnaudjuracek/svg-to-pdf
-            parent.setAttribute('style', `clip-path: ${clipPathValue.replace(/"/g, "'")}`)
-          }
+        // Handle overflow: hidden
+        if (overflowValue === 'hidden') {
+          const clipPath = $('clipPath', { id: 'clip_' + uid() }, defs, [
+            $('rect', {
+              x: x - viewBox.x,
+              y: y - viewBox.y,
+              width,
+              height
+            })
+          ])
+
+          Context.current.setAttribute('clip-path', `url(#${clipPath.id})`)
+        }
+
+        // Handle CSS clip-path property
+        if (clipPathValue !== 'none') {
+          // WARNING: CSS clip-path implementation is not done yet on arnaudjuracek/svg-to-pdf
+          Context.current.setAttribute('style', `clip-path: ${clipPathValue.replace(/"/g, "'")}`)
         }
 
         // Render element
@@ -88,7 +120,7 @@ export default function ({
         }, options)
 
         if (transform) rendered = await transform(element, rendered)
-        if (rendered) parent.appendChild(rendered)
+        if (rendered) Context.current.appendChild(rendered)
 
         // Render text nodes inside the element
         if (element.innerText && element.childNodes.length) {
@@ -127,15 +159,12 @@ export default function ({
             }
           }
 
-          if (g.children.length) parent.appendChild(g)
+          if (g.children.length) Context.current.appendChild(g)
         }
-
-        // Continue walking
-        return true
       }, {
         sort: (a, b) => {
-          a.zIndex = a.zIndex ?? getZIndex(a)
-          b.zIndex = b.zIndex ?? getZIndex(b)
+          a.zIndex ??= getZIndex(a)
+          b.zIndex ??= getZIndex(b)
           return a.zIndex - b.zIndex
         }
       })

--- a/src/utils/array-last.js
+++ b/src/utils/array-last.js
@@ -1,0 +1,1 @@
+export default arr => arr[arr.length - 1]

--- a/src/utils/dom-walk.js
+++ b/src/utils/dom-walk.js
@@ -1,8 +1,9 @@
-async function walk (element, callback, { sort = () => 1 } = {}) {
-  if (!await callback(element)) return
+async function walk (element, callback, { sort = () => 1 } = {}, depth = 0, index = 0) {
+  await callback(element, depth, index)
 
-  for (const child of Array.from(element.children).sort(sort)) {
-    await walk(child, callback, { sort })
+  const children = Array.from(element.children).sort(sort)
+  for (let index = 0; index < children.length; index++) {
+    await walk(children[index], callback, { sort }, depth + 1, index)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1128,6 +1128,11 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@lukeed/csprng@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -4605,6 +4610,13 @@ uberproto@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/uberproto/-/uberproto-1.2.0.tgz#61d4eab024f909c4e6ea52be867c4894a4beeb76"
   integrity sha512-pGtPAQmLwh+R9w81WVHzui1FfedpQWQpiaIIfPCwhtsBez4q6DYbJFfyXPVHPUTNFnedAvNEnkoFiLuhXIR94w==
+
+uid@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/uid/-/uid-2.0.2.tgz#4b5782abf0f2feeefc00fa88006b2b3b7af3e3b9"
+  integrity sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==
+  dependencies:
+    "@lukeed/csprng" "^1.0.0"
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR introduces nested `<g>` contexts, allowing support for inherited properties and flatten transformations and clipping.

This PR also adds initial support for `overflow: hidden` and `opacity`. It also fixes a bug with the `clipping-path` handling, which was "spilling" over siblings in some cases.