### PR TITLE
Add Local Font Access API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Render inline `<svg>` element as a base64 in a SVG `<image>` element.
 
 This project primarily aims at rendering printable SVG files, in which case font rendering is far more robust when outlining every texts.
 
-[Opentype.js](https://github.com/opentypejs/opentype.js) does not support (yet) loading local fonts: as a result, **every font used in in the rendering process should be explicitly declared in the render constructor** (see [Usage](#usage) below).
-
-At the time of writing, an an experimental [Local Font Access API](https://developer.chrome.com/en/articles/local-fonts/) is being tested, which could circumvent this issue. Contributions on implementing this API, or using native opt-in (or fallback) SVG `<text>` will be really appreciated.
+Fonts can be loaded from URLs declared in the render constructor (see [Usage](#usage) below), or from browser-provided `FontData` objects in environments that support the [Local Font Access API](https://developer.chrome.com/docs/capabilities/web-apis/local-fonts).
 
 ## Installation
 
@@ -92,6 +90,38 @@ download(svg.outerHTML)
 
 renderer.destroy()
 ```
+
+### Local fonts
+
+Local font enumeration must be initiated by the application from a user
+gesture. Pass the resulting `FontData` objects to the renderer:
+
+```js
+button.addEventListener('click', async () => {
+  if (!('queryLocalFonts' in window)) return
+
+  const localFonts = await window.queryLocalFonts({
+    postscriptNames: ['ArialMT']
+  })
+
+  await renderer.addLocalFonts(localFonts)
+})
+```
+
+`addLocalFonts()` parses every unique supplied font before changing the
+renderer and returns the newly added font descriptors. Repeated PostScript
+names are ignored. Constructor-declared URL fonts keep priority over local
+fonts. Requesting specific PostScript names also avoids parsing fonts the
+application does not need.
+
+The browser API requires a secure context, transient user activation, and the
+`local-fonts` permission. Applications should feature-detect it and retain
+declared URL fonts as a fallback.
+
+Font matching uses each face's OpenType weight and normalized italic or oblique
+metadata. Variable-font axes and `font-stretch` matching are not currently
+modeled. Faces in single-font or TTC/OTC collection containers are supported
+when their outline format can be parsed by the pinned OpenType.js version.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:watch": "microbundle watch",
     "example": "npm run example:build -- -w & light-server -s example -p 1337 -w 'example, example/**'",
     "example:build": "microbundle -o example -f umd --external all --compress false",
+    "test:local-fonts": "npm run build && node test/local-fonts.js",
     "preversion": "npm run build && git add dist example --force",
     "postversion": "git push && git push --tags && ghp example -f && npm publish --access public"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { uid } from 'uid'
 import walk from './utils/dom-walk'
 import getZIndex from './utils/dom-get-zindex'
 import getTextFragments from './utils/dom-get-text-fragments'
+import loadLocalFonts from './utils/local-fonts'
 import parseTransform from './utils/parse-transform'
 import lastOf from './utils/array-last'
 
@@ -17,11 +18,13 @@ export default function ({
 } = {}) {
   const cache = new Map()
   const detransformed = new Map()
+  const fontFaces = [...fonts]
+  const declaredFontCount = fontFaces.length
 
   // Init curried renderers
   const renderers = {}
   for (const k in RENDERERS) {
-    renderers[k] = RENDERERS[k]({ debug, fonts, cache })
+    renderers[k] = RENDERERS[k]({ debug, fonts: fontFaces, cache })
   }
 
   // Restore all removed transformation if any
@@ -36,9 +39,49 @@ export default function ({
     get cache () { return cache },
     cleanup,
 
+    // Parse FontData objects returned by the Local Font Access API
+    addLocalFonts: async function (fontData) {
+      const identities = new Set(fontFaces.map(font =>
+        font.postscriptName ??
+        `${font.family}\0${font.style ?? 'normal'}\0${font.weight ?? '400'}`
+      ))
+      const pendingIdentities = new Set()
+      const candidates = []
+
+      for (const data of Array.from(fontData ?? [])) {
+        const identity = data?.postscriptName
+        if (
+          identity &&
+          (identities.has(identity) || pendingIdentities.has(identity))
+        ) continue
+
+        if (identity) pendingIdentities.add(identity)
+        candidates.push(data)
+      }
+
+      const loaded = await loadLocalFonts(candidates)
+      const liveIdentities = new Set(fontFaces.map(font =>
+        font.postscriptName ??
+        `${font.family}\0${font.style ?? 'normal'}\0${font.weight ?? '400'}`
+      ))
+      const added = []
+
+      for (const font of loaded) {
+        const identity = font.postscriptName ??
+          `${font.family}\0${font.style}\0${font.weight}`
+        if (liveIdentities.has(identity)) continue
+
+        liveIdentities.add(identity)
+        added.push(font)
+      }
+
+      fontFaces.push(...added)
+      return added
+    },
+
     // Preload all fonts before resolving
     preload: async function () {
-      for (const font of fonts) {
+      for (const font of fontFaces) {
         if (font.opentype) continue
         font.opentype = await new Promise(resolve => {
           loadOpentypeFont(font.url, (error, font) => {
@@ -53,7 +96,8 @@ export default function ({
     destroy: function () {
       cache.clear()
       cleanup()
-      for (const font of fonts) delete font.opentype
+      for (const font of fontFaces) delete font.opentype
+      fontFaces.length = declaredFontCount
     },
 
     // Render the HTML container as a shadow SVG

--- a/src/utils/local-fonts.js
+++ b/src/utils/local-fonts.js
@@ -1,0 +1,237 @@
+import { parse as parseOpentypeFont } from 'opentype.js'
+
+const COLLECTION_SIGNATURE = 'ttcf'
+const COLLECTION_FACE_LIMIT = 4096
+const FONT_SIZE_LIMIT = 128 * 1024 * 1024
+const SFNT_HEADER_SIZE = 12
+const TABLE_COUNT_LIMIT = 256
+const TABLE_RECORD_SIZE = 16
+const align4 = value => Math.ceil(value / 4) * 4
+
+function assertRange (start, length, total, description) {
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(length) ||
+    start < 0 ||
+    length < 0 ||
+    start + length > total
+  ) throw new Error(`Invalid ${description}`)
+}
+
+function tag (view, offset) {
+  assertRange(offset, 4, view.byteLength, 'font signature')
+  return String.fromCharCode(
+    view.getUint8(offset),
+    view.getUint8(offset + 1),
+    view.getUint8(offset + 2),
+    view.getUint8(offset + 3)
+  )
+}
+
+function fontName (font, name) {
+  const values = font.names?.[name]
+  if (!values) return
+  return values.en ?? Object.values(values)[0]
+}
+
+function fontStyle (fontData, font) {
+  const name = fontData.style?.toLowerCase() ?? ''
+  if (name.includes('italic')) return 'italic'
+  if (name.includes('oblique')) return 'oblique'
+
+  const fsSelection = font.tables.os2?.fsSelection ?? 0
+  const macStyle = font.tables.head?.macStyle ?? 0
+  if (fsSelection & 512) return 'oblique'
+  return (fsSelection & 1) || (macStyle & 2) ? 'italic' : 'normal'
+}
+
+function fontWeight (fontData, font) {
+  const tableWeight = font.tables.os2?.usWeightClass
+  if (tableWeight) return String(tableWeight)
+
+  const name = (fontData.style ?? '').toLowerCase().replace(/[\s_-]/g, '')
+  const namedWeights = [
+    ['extralight', '200'],
+    ['ultralight', '200'],
+    ['semibold', '600'],
+    ['demibold', '600'],
+    ['extrabold', '800'],
+    ['ultrabold', '800'],
+    ['thin', '100'],
+    ['light', '300'],
+    ['medium', '500'],
+    ['black', '900'],
+    ['heavy', '900'],
+    ['bold', '700']
+  ]
+  const named = namedWeights.find(([weight]) => name.includes(weight))
+  if (named) return named[1]
+
+  return font.tables.head?.macStyle & 1 ? '700' : '400'
+}
+
+function descriptor (fontData, font) {
+  return {
+    family:
+      fontData.family ??
+      fontName(font, 'preferredFamily') ??
+      fontName(font, 'fontFamily'),
+    fullName: fontData.fullName ?? fontName(font, 'fullName'),
+    postscriptName:
+      fontData.postscriptName ??
+      fontName(font, 'postScriptName'),
+    style: fontStyle(fontData, font),
+    weight: fontWeight(fontData, font),
+    local: true,
+    opentype: font
+  }
+}
+
+function extractCollectionFace (buffer, faceOffset) {
+  const view = new DataView(buffer)
+  assertRange(
+    faceOffset,
+    SFNT_HEADER_SIZE,
+    buffer.byteLength,
+    'font collection face'
+  )
+
+  const tableCount = view.getUint16(faceOffset + 4)
+  if (!tableCount || tableCount > TABLE_COUNT_LIMIT) {
+    throw new Error('Invalid font table count')
+  }
+  const directoryLength =
+    SFNT_HEADER_SIZE + tableCount * TABLE_RECORD_SIZE
+  assertRange(
+    faceOffset,
+    directoryLength,
+    buffer.byteLength,
+    'font table directory'
+  )
+
+  const tables = []
+  let outputLength = align4(directoryLength)
+
+  for (let index = 0; index < tableCount; index++) {
+    const recordOffset =
+      faceOffset + SFNT_HEADER_SIZE + index * TABLE_RECORD_SIZE
+    const tableOffset = view.getUint32(recordOffset + 8)
+    const tableLength = view.getUint32(recordOffset + 12)
+    assertRange(
+      tableOffset,
+      tableLength,
+      buffer.byteLength,
+      'font table'
+    )
+
+    outputLength += align4(tableLength)
+    if (outputLength > FONT_SIZE_LIMIT) {
+      throw new Error('Font collection face is too large')
+    }
+
+    tables.push({ recordOffset, tableOffset, tableLength })
+  }
+
+  // OpenType.js does not read collections. Rebuild this face as a temporary
+  // standalone SFNT, retaining table bytes and rewriting their file offsets.
+  const output = new ArrayBuffer(outputLength)
+  const outputBytes = new Uint8Array(output)
+  const outputView = new DataView(output)
+  outputBytes.set(
+    new Uint8Array(buffer, faceOffset, SFNT_HEADER_SIZE),
+    0
+  )
+
+  let outputTableOffset = align4(directoryLength)
+  for (let index = 0; index < tables.length; index++) {
+    const { recordOffset, tableOffset, tableLength } = tables[index]
+    const outputRecordOffset =
+      SFNT_HEADER_SIZE + index * TABLE_RECORD_SIZE
+
+    outputBytes.set(
+      new Uint8Array(buffer, recordOffset, 8),
+      outputRecordOffset
+    )
+    outputView.setUint32(outputRecordOffset + 8, outputTableOffset)
+    outputView.setUint32(outputRecordOffset + 12, tableLength)
+    outputBytes.set(
+      new Uint8Array(buffer, tableOffset, tableLength),
+      outputTableOffset
+    )
+    outputTableOffset += align4(tableLength)
+  }
+
+  return output
+}
+
+function parseCollection (buffer, postscriptName) {
+  const view = new DataView(buffer)
+  assertRange(0, SFNT_HEADER_SIZE, buffer.byteLength, 'font collection header')
+
+  const faceCount = view.getUint32(8)
+  if (!faceCount || faceCount > COLLECTION_FACE_LIMIT) {
+    throw new Error('Invalid font collection face count')
+  }
+  assertRange(
+    SFNT_HEADER_SIZE,
+    faceCount * 4,
+    buffer.byteLength,
+    'font collection offsets'
+  )
+
+  let firstFont
+  let parseError
+
+  for (let index = 0; index < faceCount; index++) {
+    const faceOffset = view.getUint32(SFNT_HEADER_SIZE + index * 4)
+
+    try {
+      const font = parseOpentypeFont(
+        extractCollectionFace(buffer, faceOffset)
+      )
+      firstFont ??= font
+
+      if (
+        !postscriptName ||
+        fontName(font, 'postScriptName') === postscriptName
+      ) return font
+    } catch (error) {
+      parseError = error
+    }
+  }
+
+  if (!postscriptName && firstFont) return firstFont
+  throw new Error(
+    `Font collection does not contain '${postscriptName}'`,
+    { cause: parseError }
+  )
+}
+
+function parseFont (buffer, postscriptName) {
+  const view = new DataView(buffer)
+  return tag(view, 0) === COLLECTION_SIGNATURE
+    ? parseCollection(buffer, postscriptName)
+    : parseOpentypeFont(buffer)
+}
+
+export default async function (fontData) {
+  const loaded = []
+
+  for (const data of Array.from(fontData ?? [])) {
+    const name = data?.postscriptName ?? data?.fullName ?? 'unknown'
+
+    if (!data || typeof data.blob !== 'function') {
+      throw new TypeError(`Invalid local font data '${name}'`)
+    }
+
+    try {
+      const blob = await data.blob()
+      const font = parseFont(await blob.arrayBuffer(), data.postscriptName)
+      loaded.push(descriptor(data, font))
+    } catch (error) {
+      throw new Error(`Failed to parse local font '${name}'`, { cause: error })
+    }
+  }
+
+  return loaded
+}

--- a/test/local-fonts.js
+++ b/test/local-fonts.js
@@ -1,0 +1,151 @@
+const assert = require('assert').strict
+const { Blob } = require('buffer')
+const fs = require('fs')
+const path = require('path')
+
+const HtmlToSvg = require('../dist/html-to-svg.js')
+
+const bytes = fs.readFileSync(
+  path.resolve(__dirname, '../example/fonts/ahem.ttf')
+)
+const robotoBytes = fs.readFileSync(
+  path.resolve(__dirname, '../example/fonts/roboto-regular.ttf')
+)
+
+const align4 = value => Math.ceil(value / 4) * 4
+
+function fontCollection (...fonts) {
+  const headerLength = 12 + fonts.length * 4
+  const offsets = []
+  let collectionLength = align4(headerLength)
+
+  for (const font of fonts) {
+    offsets.push(collectionLength)
+    collectionLength = align4(collectionLength + font.length)
+  }
+
+  const collection = Buffer.alloc(collectionLength)
+
+  collection.write('ttcf', 0, 'ascii')
+  collection.writeUInt32BE(0x00010000, 4)
+  collection.writeUInt32BE(fonts.length, 8)
+
+  for (let face = 0; face < fonts.length; face++) {
+    const font = fonts[face]
+    const faceOffset = offsets[face]
+    collection.writeUInt32BE(faceOffset, 12 + face * 4)
+    font.copy(collection, faceOffset)
+    const tableCount = font.readUInt16BE(4)
+
+    for (let index = 0; index < tableCount; index++) {
+      const sourceRecord = 12 + index * 16
+      const collectionRecord = faceOffset + sourceRecord
+      collection.writeUInt32BE(
+        font.readUInt32BE(sourceRecord + 8) + faceOffset,
+        collectionRecord + 8
+      )
+    }
+  }
+
+  return collection
+}
+
+function localFont ({
+  family = 'Ahem',
+  fullName = 'Ahem',
+  postscriptName = 'Ahem',
+  style = 'Regular',
+  contents = bytes
+} = {}) {
+  return {
+    family,
+    fullName,
+    postscriptName,
+    style,
+    blob: async () => new Blob([contents])
+  }
+}
+
+async function main () {
+  const concurrentRenderer = new HtmlToSvg()
+  const concurrent = await Promise.all([
+    concurrentRenderer.addLocalFonts([localFont()]),
+    concurrentRenderer.addLocalFonts([localFont()])
+  ])
+  assert.equal(concurrent[0].length + concurrent[1].length, 1)
+  concurrentRenderer.destroy()
+
+  const renderer = new HtmlToSvg()
+  const added = await renderer.addLocalFonts([localFont()])
+
+  assert.equal(added.length, 1)
+  assert.equal(added[0].family, 'Ahem')
+  assert.equal(added[0].fullName, 'Ahem')
+  assert.equal(added[0].postscriptName, 'Ahem')
+  assert.equal(added[0].style, 'normal')
+  assert.equal(added[0].weight, '400')
+  assert.equal(added[0].local, true)
+  assert.equal(typeof added[0].opentype.getPath, 'function')
+
+  assert.deepEqual(await renderer.addLocalFonts([localFont()]), [])
+  assert.deepEqual(await renderer.addLocalFonts([{
+    postscriptName: 'Ahem',
+    blob: async () => {
+      throw new Error('duplicate blobs must not be read')
+    }
+  }]), [])
+
+  await assert.rejects(
+    renderer.addLocalFonts([
+      localFont({ postscriptName: 'AhemTwo' }),
+      localFont({
+        fullName: 'Broken',
+        postscriptName: 'Broken',
+        contents: new Uint8Array([0, 1, 2, 3])
+      })
+    ]),
+    /Failed to parse local font 'Broken'/
+  )
+
+  const afterFailure = await renderer.addLocalFonts([
+    localFont({ postscriptName: 'AhemTwo', style: 'Italic' })
+  ])
+  assert.equal(afterFailure.length, 1)
+  assert.equal(afterFailure[0].style, 'italic')
+
+  renderer.destroy()
+  assert.equal(afterFailure[0].opentype, undefined)
+
+  const collection = await renderer.addLocalFonts([
+    localFont({
+      contents: fontCollection(bytes, robotoBytes),
+      family: 'Roboto',
+      fullName: 'Roboto Regular',
+      postscriptName: 'Roboto-Regular'
+    })
+  ])
+  assert.equal(collection.length, 1)
+  assert.equal(collection[0].postscriptName, 'Roboto-Regular')
+
+  await assert.rejects(
+    renderer.addLocalFonts([
+      localFont({
+        contents: fontCollection(bytes, robotoBytes),
+        postscriptName: 'MissingFace'
+      })
+    ]),
+    error => {
+      assert.match(error.message, /Failed to parse local font 'MissingFace'/)
+      assert.match(
+        error.cause.message,
+        /Font collection does not contain 'MissingFace'/
+      )
+      return true
+    }
+  )
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- add `renderer.addLocalFonts(fontData)` for explicit ingestion of `FontData` records returned by the Local Font Access API
- keep enumeration, transient user activation, and permission handling in application code; the library never invokes `queryLocalFonts()` automatically
- parse batches transactionally and sequentially, skip known duplicates before blob access, and recheck live identities at commit time for concurrent calls
- normalize family, PostScript/full names, OpenType weight, italic/oblique style, and lifecycle metadata into the renderer's existing font descriptor shape
- support TTC/OTC collection-backed faces by rebuilding a bounded standalone SFNT and selecting the requested PostScript name
- remove local faces and their parsed OpenType graphs on `destroy()`
- document feature detection, security requirements, fallback behavior, and variable/stretch limitations

## Validation

- `yarn install --frozen-lockfile`
- `yarn test:local-fonts`
- focused ESLint over changed source and tests
- `git diff --check`
- deterministic tests for parsing, pre-I/O and concurrent deduplication, atomic failure, metadata, cleanup/re-add, malformed input, and second-face selection from a mixed Ahem/Roboto collection
- headless Chrome public-API smoke: one real glyph path from a FontData-shaped Ahem record, duplicate suppression, cleanup/re-add, constructor-font precedence, native API feature detection, and no browser errors

## API and privacy boundary

Usage remains explicit:

```js
button.addEventListener('click', async () => {
  const fontData = await window.queryLocalFonts({
    postscriptNames: ['ArialMT']
  })
  await renderer.addLocalFonts(fontData)
})
```

The browser remains responsible for secure-context checks, transient activation, permissions policy, and user consent. Constructor-declared URL fonts retain priority and remain the fallback for unsupported browsers or outline formats that the pinned OpenType.js cannot parse.
