### PR TITLE
Upgrade to OpenType.js 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "gradient-parser": "^1.0.2",
-    "opentype.js": "1.3.4",
+    "opentype.js": "2.0.0",
     "transformation-matrix": "^3.0.0",
     "uid": "^2.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { load as loadOpentypeFont } from 'opentype.js'
+import * as Opentype from 'opentype.js'
 import { uid } from 'uid'
 
 import walk from './utils/dom-walk'
@@ -9,6 +9,8 @@ import lastOf from './utils/array-last'
 
 import $ from './utils/dom-render-svg'
 import * as RENDERERS from './renderers'
+
+const parseOpentypeFont = Opentype.parse ?? Opentype.default?.parse
 
 export default function ({
   debug = false,
@@ -40,12 +42,14 @@ export default function ({
     preload: async function () {
       for (const font of fonts) {
         if (font.opentype) continue
-        font.opentype = await new Promise(resolve => {
-          loadOpentypeFont(font.url, (error, font) => {
-            if (error) throw error
-            resolve(font)
-          })
-        })
+        const response = await fetch(font.url)
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load font '${font.url}': ` +
+            `${response.status} ${response.statusText}`
+          )
+        }
+        font.opentype = parseOpentypeFont(await response.arrayBuffer())
       }
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,13 +3464,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
-opentype.js@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/opentype.js/-/opentype.js-1.3.4.tgz#1c0e72e46288473cc4a4c6a2dc60fd7fe6020d77"
-  integrity sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==
-  dependencies:
-    string.prototype.codepointat "^0.2.1"
-    tiny-inflate "^1.0.3"
+opentype.js@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/opentype.js/-/opentype.js-2.0.0.tgz#b87fcec8107075aabb6f50fe5e6bb4d8db6c8c7d"
+  integrity sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==
 
 optionator@^0.9.3:
   version "0.9.3"
@@ -4356,11 +4353,6 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.codepointat@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
-  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
-
 string.prototype.matchall@^4.0.6:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
@@ -4512,11 +4504,6 @@ tiny-glob@^0.2.8:
   dependencies:
     globalyzer "0.1.0"
     globrex "^0.1.2"
-
-tiny-inflate@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
-  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
## Summary

- upgrade `opentype.js` from the exact `1.3.4` release to the exact `2.0.0` release
- replace the deprecated callback loader with `fetch()` plus `parse()`
- report HTTP failures before attempting to parse a font
- support OpenType.js's CommonJS and ESM export shapes

## Why this is a draft

OpenType.js 2.0.0 has a GSUB type 6 format 2 regression that affects contextual shaping in real fonts. The upstream fix is open as [opentypejs/opentype.js#861](https://github.com/opentypejs/opentype.js/pull/861).

This PR should remain draft until that fix is merged and included in a 2.x release. The dependency can then be updated to that fixed release before this PR is marked ready.

## Validation

- frozen Yarn install
- ESLint on `src/index.js`
- library build
- standalone example build
- browser smoke: every example section rendered, Roboto and Ahem produced paths, and an invalid font URL surfaced its HTTP 404
